### PR TITLE
Workflow to create PR for sync Upstream repo changes

### DIFF
--- a/.github/workflows/fetch-upstream-origin-changes.yml
+++ b/.github/workflows/fetch-upstream-origin-changes.yml
@@ -1,0 +1,34 @@
+name: Sync Upstream
+
+on:
+  workflow_call:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Add upstream remote
+        run: git remote add upstream https://github.com/fiterpaystack/web-app.git
+
+      - name: Fetch upstream
+        run: git fetch upstream
+
+      - name: Create sync branch
+        run: |
+          git checkout -B sync-upstream upstream/main
+          git push origin sync-upstream --force
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e #v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'Sync from fiterpaystack/web-app upstream repo'
+          branch: sync-upstream
+          title: '🔄 Sync from fiterpaystack/web-app'
+          body: 'Sync from upstream repo(fiterpaystack/web-app)'


### PR DESCRIPTION
- Creating this workflow to create PR for Sync Upstream repo(fiterpaystack/web-app)

Context:
We are switching the Paystack-MFB/web-app repository to private because it's currently public, which is causing blockers for running certain build and deployment workflows.

Plan:
- Remove the fork from the Paystack-MFB/web-app repo and make it private.
- Use this workflow to fetching changes from the upstream repository into our private web-app repo.

[JiraTicket](https://paystack.atlassian.net/browse/IDEVOPS-1427)
